### PR TITLE
feat: add ldap identity

### DIFF
--- a/src/main/java/com/sitepark/ies/sharedkernel/security/Identity.java
+++ b/src/main/java/com/sitepark/ies/sharedkernel/security/Identity.java
@@ -1,0 +1,25 @@
+package com.sitepark.ies.sharedkernel.security;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+/**
+ * The <code>Identity</code> interface represents a user's identity for authentication purposes.
+ * Classes like {@link LdapIdentity} implement this interface to specify how users can authenticate
+ * themselves using different identity providers.
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME)
+@JsonSubTypes({
+  @JsonSubTypes.Type(value = LdapIdentity.class, name = "ldap"),
+  @JsonSubTypes.Type(value = InternalIdentity.class, name = "internal")
+})
+public interface Identity {
+
+  static Identity internal() {
+    return InternalIdentity.getInstance();
+  }
+
+  static Identity ldap(int serverId, String dn) {
+    return new LdapIdentity(serverId, dn);
+  }
+}

--- a/src/main/java/com/sitepark/ies/sharedkernel/security/InternalIdentity.java
+++ b/src/main/java/com/sitepark/ies/sharedkernel/security/InternalIdentity.java
@@ -1,0 +1,30 @@
+package com.sitepark.ies.sharedkernel.security;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+public final class InternalIdentity implements Identity {
+
+  private static final InternalIdentity INSTANCE = new InternalIdentity();
+
+  private InternalIdentity() {}
+
+  @JsonCreator
+  static InternalIdentity getInstance() {
+    return INSTANCE;
+  }
+
+  @Override
+  public String toString() {
+    return "InternalIdentity{}";
+  }
+
+  @Override
+  public int hashCode() {
+    return InternalIdentity.class.hashCode();
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    return obj instanceof InternalIdentity;
+  }
+}

--- a/src/main/java/com/sitepark/ies/sharedkernel/security/LdapIdentity.java
+++ b/src/main/java/com/sitepark/ies/sharedkernel/security/LdapIdentity.java
@@ -1,0 +1,60 @@
+package com.sitepark.ies.sharedkernel.security;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
+
+/**
+ * The <code>LdapIdentity</code> class represents an identity provider using LDAP for user
+ * authentication. It facilitates user authentication and access control using LDAP credentials.
+ */
+@SuppressWarnings({"PMD.AvoidFieldNameMatchingMethodName"})
+public final class LdapIdentity implements Identity {
+
+  private final int serverId;
+
+  private final String dn;
+
+  @JsonCreator
+  LdapIdentity(@JsonProperty("serverId") int serverId, @JsonProperty("dn") String dn) {
+    if (serverId <= 0) {
+      throw new IllegalArgumentException("serverId must be greater than 0");
+    }
+    Objects.requireNonNull(dn, "db must not be null");
+    if (dn.isBlank()) {
+      throw new IllegalArgumentException("dn must not be blank");
+    }
+    this.serverId = serverId;
+    this.dn = dn;
+  }
+
+  @JsonProperty
+  public int serverId() {
+    return this.serverId;
+  }
+
+  @JsonProperty
+  public String dn() {
+    return this.dn;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(this.serverId, this.dn);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+
+    if (!(o instanceof LdapIdentity that)) {
+      return false;
+    }
+
+    return Objects.equals(this.serverId, that.serverId) && Objects.equals(this.dn, that.dn);
+  }
+
+  @Override
+  public String toString() {
+    return "LdapIdentity{" + "serverId=" + serverId + ", dn='" + dn + '\'' + '}';
+  }
+}

--- a/src/main/java/com/sitepark/ies/sharedkernel/security/User.java
+++ b/src/main/java/com/sitepark/ies/sharedkernel/security/User.java
@@ -18,9 +18,11 @@ public final class User {
   private final String firstName;
   @NotNull private final String lastName;
   private final String email;
+  private final Identity identity;
   private final List<AuthMethod> authMethods;
   private final List<AuthFactor> authFactors;
 
+  @SuppressWarnings({"PMD.LawOfDemeter"})
   private User(Builder builder) {
 
     this.id = builder.id;
@@ -28,6 +30,7 @@ public final class User {
     this.firstName = builder.firstName;
     this.lastName = builder.lastName;
     this.email = builder.email;
+    this.identity = builder.identity;
     this.authMethods = List.copyOf(builder.authMethods);
     this.authFactors = List.copyOf(builder.authFactors);
 
@@ -37,6 +40,7 @@ public final class User {
     if (this.lastName.isBlank()) {
       throw new IllegalArgumentException("lastName cannot be blank");
     }
+    Objects.requireNonNull(this.identity, "identity cannot be null");
   }
 
   @JsonProperty
@@ -65,6 +69,11 @@ public final class User {
   }
 
   @JsonProperty
+  public Identity identity() {
+    return identity;
+  }
+
+  @JsonProperty
   public List<AuthMethod> authMethods() {
     return List.copyOf(authMethods);
   }
@@ -89,7 +98,8 @@ public final class User {
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, username, firstName, lastName, email, authMethods, authFactors);
+    return Objects.hash(
+        id, username, firstName, lastName, email, identity, authMethods, authFactors);
   }
 
   @Override
@@ -102,6 +112,7 @@ public final class User {
         && Objects.equals(this.firstName, that.firstName)
         && Objects.equals(this.lastName, that.lastName)
         && Objects.equals(this.email, that.email)
+        && Objects.equals(this.identity, that.identity)
         && Objects.equals(this.authMethods, that.authMethods)
         && Objects.equals(this.authFactors, that.authFactors);
   }
@@ -124,6 +135,8 @@ public final class User {
         + ", email='"
         + email
         + '\''
+        + ", identity="
+        + identity
         + ", authMethods="
         + authMethods
         + ", authFactors="
@@ -140,6 +153,7 @@ public final class User {
   }
 
   @JsonPOJOBuilder(withPrefix = "")
+  @SuppressWarnings({"PMD.LawOfDemeter"})
   public static final class Builder {
 
     private String id;
@@ -147,6 +161,7 @@ public final class User {
     private String firstName;
     private String lastName;
     private String email;
+    private Identity identity = Identity.internal();
     private final List<AuthMethod> authMethods = new ArrayList<>();
     private final List<AuthFactor> authFactors = new ArrayList<>();
 
@@ -159,6 +174,7 @@ public final class User {
       this.firstName = user.firstName;
       this.lastName = user.lastName;
       this.email = user.email;
+      this.identity = user.identity;
       this.authMethods.addAll(user.authMethods);
       this.authFactors.addAll(user.authFactors);
     }
@@ -190,6 +206,12 @@ public final class User {
     public Builder email(String email) {
       Objects.requireNonNull(email, "email cannot be null");
       this.email = email;
+      return this;
+    }
+
+    public Builder identity(Identity identity) {
+      Objects.requireNonNull(identity, "identity cannot be null");
+      this.identity = identity;
       return this;
     }
 

--- a/src/test/java/com/sitepark/ies/sharedkernel/security/IdentityTest.java
+++ b/src/test/java/com/sitepark/ies/sharedkernel/security/IdentityTest.java
@@ -1,0 +1,18 @@
+package com.sitepark.ies.sharedkernel.security;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class IdentityTest {
+  @Test
+  void testInternal() {
+    assertInstanceOf(InternalIdentity.class, Identity.internal());
+  }
+
+  @Test
+  void testLdap() {
+    assertInstanceOf(
+        LdapIdentity.class, Identity.ldap(1, "cn=Test User,ou=users,dc=example,dc=com"));
+  }
+}

--- a/src/test/java/com/sitepark/ies/sharedkernel/security/InternalIdentityTest.java
+++ b/src/test/java/com/sitepark/ies/sharedkernel/security/InternalIdentityTest.java
@@ -1,0 +1,20 @@
+package com.sitepark.ies.sharedkernel.security;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.jparams.verifier.tostring.ToStringVerifier;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
+
+class InternalIdentityTest {
+
+  @Test
+  void testEquals() {
+    EqualsVerifier.forClass(InternalIdentity.class).verify();
+  }
+
+  @Test
+  void testToString() {
+    ToStringVerifier.forClass(InternalIdentity.class).verify();
+  }
+}

--- a/src/test/java/com/sitepark/ies/sharedkernel/security/LdapIdentityTest.java
+++ b/src/test/java/com/sitepark/ies/sharedkernel/security/LdapIdentityTest.java
@@ -1,0 +1,103 @@
+package com.sitepark.ies.sharedkernel.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.jparams.verifier.tostring.ToStringVerifier;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
+
+@SuppressFBWarnings({
+  "PI_DO_NOT_REUSE_PUBLIC_IDENTIFIERS_CLASS_NAMES",
+  "NP_NULL_PARAM_DEREF_NONVIRTUAL",
+  "NP_NULL_PARAM_DEREF_ALL_TARGETS_DANGEROUS"
+})
+class LdapIdentityTest {
+
+  private static final String USER_DN = "userdn";
+
+  @Test
+  void testEquals() {
+    EqualsVerifier.forClass(LdapIdentity.class).verify();
+  }
+
+  @Test
+  void testToString() {
+    ToStringVerifier.forClass(LdapIdentity.class).verify();
+  }
+
+  @Test
+  void testSetServer() throws JsonProcessingException {
+    LdapIdentity ldapIdentity = new LdapIdentity(2, USER_DN);
+    assertEquals(2, ldapIdentity.serverId(), "unexpected server");
+  }
+
+  @Test
+  void testSetInvalidServer() throws JsonProcessingException {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          new LdapIdentity(0, USER_DN);
+        });
+  }
+
+  @Test
+  void testSetNullDn() throws JsonProcessingException {
+    assertThrows(
+        NullPointerException.class,
+        () -> {
+          new LdapIdentity(1, null);
+        });
+  }
+
+  @Test
+  void testSetBlankDn() throws JsonProcessingException {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          new LdapIdentity(1, " ");
+        });
+  }
+
+  @Test
+  void testSetDn() throws JsonProcessingException {
+    LdapIdentity ldapIdentity = new LdapIdentity(2, USER_DN);
+    assertEquals(USER_DN, ldapIdentity.dn(), "unexpected server");
+  }
+
+  @Test
+  void testSerialize() throws JsonProcessingException {
+
+    ObjectMapper mapper = new ObjectMapper();
+    mapper.setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
+
+    LdapIdentity ldapIdentity = new LdapIdentity(2, USER_DN);
+
+    String json = mapper.writeValueAsString(ldapIdentity);
+
+    String expected = "{\"@type\":\"ldap\",\"serverId\":2,\"dn\":\"userdn\"}";
+
+    assertEquals(expected, json, "unexpected json");
+  }
+
+  @Test
+  void testDeserialize() throws JsonProcessingException {
+
+    ObjectMapper mapper = new ObjectMapper();
+    SimpleModule module = new SimpleModule();
+    mapper.registerModule(module);
+
+    String json = "{\"@type\":\"ldap\",\"serverId\":2,\"dn\":\"userdn\"}";
+
+    LdapIdentity ldapIdentity = mapper.readValue(json, LdapIdentity.class);
+
+    LdapIdentity expected = new LdapIdentity(2, USER_DN);
+
+    assertEquals(expected, ldapIdentity, "unexpected ldapIdentity");
+  }
+}

--- a/src/test/java/com/sitepark/ies/sharedkernel/security/UserTest.java
+++ b/src/test/java/com/sitepark/ies/sharedkernel/security/UserTest.java
@@ -54,6 +54,7 @@ class UserTest {
             .firstName(" ")
             .lastName("User")
             .email("test@test.com")
+            .identity(Identity.internal())
             .authMethods(AuthMethod.PASSWORD)
             .authFactors(AuthFactor.TOTP)
             .build();
@@ -69,6 +70,7 @@ class UserTest {
             .username("testUser")
             .lastName("User")
             .email("test@test.com")
+            .identity(Identity.internal())
             .authMethods(AuthMethod.PASSWORD)
             .authFactors(AuthFactor.TOTP)
             .build();
@@ -140,6 +142,7 @@ class UserTest {
             .username("testUser")
             .lastName("User")
             .email("test@test.com")
+            .identity(Identity.internal())
             .authMethods(AuthMethod.PASSWORD)
             .authFactors(AuthFactor.TOTP)
             .build()
@@ -153,6 +156,7 @@ class UserTest {
             .username("testUser")
             .lastName("User")
             .email("test2@test.com")
+            .identity(Identity.internal())
             .authMethods(AuthMethod.PASSWORD)
             .authFactors(AuthFactor.TOTP)
             .build();
@@ -167,7 +171,7 @@ class UserTest {
 
     String expected =
         """
-        {"id":"1","username":"testUser","firstName":"Test","lastName":"User","email":"test@test.com","authMethods":["PASSWORD"],"authFactors":["TOTP"]}""";
+        {"id":"1","username":"testUser","firstName":"Test","lastName":"User","email":"test@test.com","identity":{"@type":"internal"},"authMethods":["PASSWORD"],"authFactors":["TOTP"]}""";
 
     assertEquals(expected, json, "Serialized JSON should match expected format");
   }
@@ -177,7 +181,7 @@ class UserTest {
     ObjectMapper mapper = new ObjectMapper();
     String json =
         """
-        {"id":"1","username":"testUser","firstName":"Test","lastName":"User","email":"test@test.com","authMethods":["PASSWORD"],"authFactors":["TOTP"]}""";
+        {"id":"1","username":"testUser","firstName":"Test","lastName":"User","email":"test@test.com","identity":{"@type":"internal"},"authMethods":["PASSWORD"],"authFactors":["TOTP"]}""";
     User user = mapper.readValue(json, User.class);
 
     assertEquals(this.user, user, "Deserialized User should match original User");


### PR DESCRIPTION
Users can also authenticate themselves to an LDAP system, for which the user object must be extended.