### PR TITLE
build: treat Error Prone/javac warnings as errors (-Werror)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -155,6 +155,8 @@
 						<arg>-XDcompilePolicy=simple</arg>
 						<arg>--should-stop=ifError=FLOW</arg>
 						<arg>-Xplugin:ErrorProne -Xep:NullAway:ERROR -XepOpt:NullAway:JSpecifyMode=true -XepOpt:NullAway:AnnotatedPackages=com.sitepark.ies</arg>
+						<!-- Treat every Error Prone / javac warning as a build error. -->
+						<arg>-Werror</arg>
 					</compilerArgs>
 					<annotationProcessorPaths>
 						<path>

--- a/src/main/java/com/sitepark/ies/sharedkernel/anchor/Anchor.java
+++ b/src/main/java/com/sitepark/ies/sharedkernel/anchor/Anchor.java
@@ -110,6 +110,6 @@ public final class Anchor implements Serializable {
 
   @Override
   public String toString() {
-    return this == EMPTY ? "EMPTY" : this.name;
+    return this.name.isEmpty() ? "EMPTY" : this.name;
   }
 }

--- a/src/main/java/com/sitepark/ies/sharedkernel/base/Identifier.java
+++ b/src/main/java/com/sitepark/ies/sharedkernel/base/Identifier.java
@@ -64,7 +64,7 @@ public final class Identifier implements Comparable<Identifier> {
 
   public static Identifier ofAnchor(Anchor anchor) {
     Objects.requireNonNull(anchor, "anchor is null");
-    if (anchor == Anchor.EMPTY) {
+    if (Anchor.EMPTY.equals(anchor)) {
       throw new IllegalArgumentException("anchor is empty");
     }
     return new Identifier(anchor);

--- a/src/main/java/com/sitepark/ies/sharedkernel/base/Updatable.java
+++ b/src/main/java/com/sitepark/ies/sharedkernel/base/Updatable.java
@@ -123,7 +123,7 @@ import org.jspecify.annotations.Nullable;
  *     <th>Best For</th>
  *   </tr>
  *   <tr>
- *     <td>{@code Optional&lt;T&gt;}</td>
+ *     <td>{@code Optional<T>}</td>
  *     <td>Optional.empty()</td>
  *     <td>Optional.empty()</td>
  *     <td>Optional.of(value)</td>
@@ -144,7 +144,7 @@ import org.jspecify.annotations.Nullable;
  *     <td>Only annotation, no runtime info</td>
  *   </tr>
  *   <tr>
- *     <td><strong>{@code Updatable&lt;T&gt;}</strong></td>
+ *     <td><strong>{@code Updatable<T>}</strong></td>
  *     <td><strong>Updatable.unchanged()</strong></td>
  *     <td><strong>Updatable.of(null)</strong></td>
  *     <td><strong>Updatable.of(value)</strong></td>

--- a/src/main/java/com/sitepark/ies/sharedkernel/email/ExternalEmailParameters.java
+++ b/src/main/java/com/sitepark/ies/sharedkernel/email/ExternalEmailParameters.java
@@ -16,6 +16,7 @@ public record ExternalEmailParameters(
     replyTo = replyTo == null ? List.of() : List.copyOf(replyTo);
   }
 
+  @Override
   public List<EmailAddress> replyTo() {
     return List.copyOf(replyTo);
   }

--- a/src/main/java/com/sitepark/ies/sharedkernel/security/PermissionService.java
+++ b/src/main/java/com/sitepark/ies/sharedkernel/security/PermissionService.java
@@ -6,26 +6,36 @@ import java.util.Map;
 public interface PermissionService {
 
   /**
+   * Creates a permission from the given raw attribute map.
+   *
    * @throws PermissionCreateException Thrown when the permission could not be created.
    */
   Permission createPermission(Map<String, Object> permission);
 
   /**
+   * Serializes the given permissions into their string representation.
+   *
    * @throws PermissionSerializeException Thrown when the permission could not be serialized.
    */
   String serializePermissions(List<Permission> permissions);
 
   /**
+   * Serializes the given permission into its string representation.
+   *
    * @throws PermissionSerializeException Thrown when the permission could not be serialized.
    */
   String serializePermission(Permission permission);
 
   /**
+   * Deserializes the given data into a list of permissions.
+   *
    * @throws PermissionDeserializeException Thrown when the permission could not be deserialized.
    */
   List<Permission> deserializePermissions(String data);
 
   /**
+   * Deserializes the given data into a single permission.
+   *
    * @throws PermissionDeserializeException Thrown when the permission could not be deserialized.
    */
   Permission deserializePermission(String data);


### PR DESCRIPTION
Add -Werror to the main compiler args so every Error Prone and javac warning fails the build; the test compile override stays lenient. Fix the findings this surfaced:

- ReferenceEquality: use value equality against Anchor.EMPTY
- EscapedEntity: drop HTML entities inside {@code} in Updatable javadoc
- MissingOverride: annotate the record accessor in ExternalEmailParameters
- MissingSummary: add summary lines to PermissionService javadoc